### PR TITLE
DeepL Ignored Global Strings improvement

### DIFF
--- a/app/Engines/DeepL/DeepLEngine.php
+++ b/app/Engines/DeepL/DeepLEngine.php
@@ -312,15 +312,12 @@ final class DeepLEngine implements FluencyEngine {
       ...$ignoredStrings
     ]);
 
+    // Ignore longest strings first
+    usort($ignoredStrings, fn ($a, $b) => strlen($b) <=> strlen($a));
+
     return array_map(function($value) use ($ignoredStrings) {
       return array_reduce($ignoredStrings, function($text, $ignored) {
-        preg_match_all('/' . preg_quote($ignored) . '/', $text, $matches);
-
-        if (count($matches[0])) {
-          return $text = str_replace($ignored, "<span translate=\"no\">{$ignored}</span>", $text);
-        }
-
-        return $text;
+        return preg_replace('/\b' . preg_quote($ignored) . '?\b/', "<span translate=\"no\">{$ignored}</span>", $text);
       }, $value);
     }, $texts);
   }


### PR DESCRIPTION
This pull request does 2 things:

1. Sort string by longest to shortest before adding the ignored tag.
    Example with:
    `potatoes || I am harvesting potatoes`

    Before:
    ```html
    I am harvesting <span translate="no">potatoes</span>
    ```
    After:
    ```html
    <span translate="no">I am harvesting <span translate="no">potatoes</span></span>
    ```

2. Match strings by word boundaries in order to avoid adding ignored tags in the middle of a word.
    Example with
    `potato || potatoes`
  
    Before:
    ```html
    <span translate="no">potato</span>es
    ```
    After:
    ```html
    <span translate="no">potatoes</span>
    ```